### PR TITLE
Fall back to <html> if #js-repo-pjax-container is missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var gitHubInjection = function (global, cb) {
     throw new Error('Callback is not a function');
   }
 
-  var domElement = global.document.getElementById('js-repo-pjax-container');
+  var domElement = global.document.getElementById('js-repo-pjax-container') || global.document.documentElement;
   if (!domElement || !global.MutationObserver) {
     return cb(null);
   }


### PR DESCRIPTION
This allows this module to be used with [Turbolinks](https://github.com/turbolinks/turbolinks) sites like GitLab.
For a demo:
- Visit https://gitlab.com/gitlab-org/gitlab-ce
- Paste the contents of this file into the console
- Paste the following into the console:

``` javascript
gitHubInjection(window, function(err) {
  if (err) {
    return console.error(err);
  }
  console.warn("XXX INJECTION");
});
```
- Click the "Activity" link
- Notice "XXX INJECTION" printed to the console

See https://github.com/OctoLinker/browser-extension/issues/113
