### PR TITLE
Add description to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-injection",
-  "description": "",
+  "description": "Tiny script which helps you to build better browser extensions for GitHub.com",
   "version": "0.3.0",
   "homepage": "https://github.com/octo-linker/injection",
   "bugs": "https://github.com/octo-linker/injection/issues",


### PR DESCRIPTION
Because npm is parsing the wrong one out of the readme:

<img width="530" alt="wrong description" src="https://user-images.githubusercontent.com/1402241/27309463-7e51bb0a-5586-11e7-9f74-254ce07a11c2.png">
