### PR TITLE
Observe fewer unnecessary events

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,16 +25,14 @@ var gitHubInjection = function (global, cb) {
 
   var viewSpy = new global.MutationObserver(function (mutations) {
     mutations.forEach(function (mutation) {
-      if (mutation.type === 'childList' && mutation.addedNodes.length) {
+      if (mutation.addedNodes.length) {
         cb(null);
       }
     });
   });
 
   viewSpy.observe(domElement, {
-    attributes: true,
-    childList: true,
-    characterData: true
+    childList: true
   });
 
   cb(null);


### PR DESCRIPTION
The observer filters out anything that isn't a `childList` mutation, so `attributes` and `characterData` should go.