### PR TITLE
Use new event

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const gitHubInjection = cb => {
     throw new TypeError('Callback is not a function');
   }
 
-  document.addEventListener('turbo:visit', cb);
+  document.addEventListener('turbo:render', cb);
   cb();
 };
 

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const gitHubInjection = cb => {
     throw new TypeError('Callback is not a function');
   }
 
+  document.addEventListener('pjax:end', cb);
   document.addEventListener('turbo:render', cb);
   cb();
 };

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const gitHubInjection = cb => {
     throw new TypeError('Callback is not a function');
   }
 
-  document.addEventListener('pjax:end', cb);
+  document.addEventListener('turbo:visit', cb);
   cb();
 };
 


### PR DESCRIPTION
Here's the new sequence of events:

<img width="284" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/176352308-7fc7b93a-2290-4e4e-8403-bd47e7aa5350.png">

Note: `turbo:load` is triggered on the first load too: https://github.com/refined-github/refined-github/issues/5738#issuecomment-1169520591